### PR TITLE
[Enhance] Add format & min, max length for company

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -198,6 +198,8 @@ paths:
           required: true
           schema:
             type: string
+            minLength: 1
+            maxLength: 128
         - name: next
           in: query
           description: ID to start the search from for pagination
@@ -450,6 +452,7 @@ components:
       properties:
         id:
           type: string
+          format: uuid
           description: "회사 식별자"
         name:
           type: string


### PR DESCRIPTION
- 제약조건 추가
	- 식별자 uuid format
	- 회사명 최대 최소 길이 추가
		- 데이터 상 직장명 최대 길이 90자(`(국토건설(일용)SAMSUNG SDI C/F Building Demolition and Electrode Mother-Line Construction Project)`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- API의 입력 유효성을 개선하기 위해 문자열 매개변수에 최소 및 최대 길이 제약 조건 추가.
	- 식별자에 UUID 형식 요구 사항 추가로 데이터 일관성 강화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->