### PR TITLE
✨ 프로필 위젯 삭제 API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -220,7 +220,7 @@ paths:
       security:
         - BearerAuth: [ ]
       parameters:
-        - in: query
+        - in: path
           name: type
           required: true
           schema:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -211,6 +211,30 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
+    delete:
+      summary: 프로필 위젯 삭제
+      description: 현재 사용자의 프로필 위젯을 삭제합니다.
+      tags:
+        - users
+      operationId: deleteProfileWidget
+      security:
+        - BearerAuth: [ ]
+      parameters:
+        - in: query
+          name: type
+          required: true
+          schema:
+            $ref: '#/components/schemas/ProfileWidgetType'
+          description: 삭제할 프로필 위젯 타입
+      responses:
+        '204':
+          description: 프로필 위젯 삭제 성공
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /auth/token/refresh:
     post:
@@ -280,7 +304,7 @@ paths:
                 items:
                   $ref: '#/components/schemas/Location'
         '404':
-            $ref: '#/components/responses/NotFound'
+          $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/InternalServerError'
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -211,6 +211,7 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '500':
           $ref: '#/components/responses/InternalServerError'
+  /users/profileWidgets/{type}:
     delete:
       summary: 프로필 위젯 삭제
       description: 현재 사용자의 프로필 위젯을 삭제합니다.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- 사용자 프로필 위젯을 삭제할 수 있는 새로운 API 엔드포인트 추가 (`/users/profileWidgets`).
	- 프로필 위젯 삭제 시 `204` 상태 코드 반환.
- **버그 수정**
	- `GET /locations/{regionName}` 엔드포인트의 `404` 응답 참조 수정.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->