### PR TITLE
✨ 프로필 수정 API 변경

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -154,7 +154,7 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
-    patch:
+    put:
       summary: 내 프로필 수정
       description: 현재 로그인한 사용자의 프로필 정보를 수정합니다. (이름, 직군, 직장, 활동 지역)
       tags:
@@ -693,10 +693,12 @@ components:
           $ref: '#/components/schemas/JobOccupation'
         companyId:
           type: string
+          nullable: true
           format: uuid
           description: 사용자의 회사 ID
         allowSameCompany:
             type: boolean
+            nullable: true
             description: 같은 회사에 근무하는 파트너를 허용하는지 여부 (companyID가 없을 경우 null)
         locationIds:
           type: array
@@ -704,6 +706,10 @@ components:
             type: string
             format: uuid
           description: 사용자의 활동 지역 목록 ID 리스트
+      required:
+        - name
+        - jobOccupation
+        - locationIds
 
     UpdateMyUserInfoResponse:
       type: object


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 프로필 업데이트를 위한 API 엔드포인트의 HTTP 메서드가 `PATCH`에서 `PUT`으로 변경되어 전체 데이터 교체가 가능해졌습니다.
	- 사용자 정보 업데이트 요청 스키마에 `companyId` 및 `allowSameCompany` 속성이 추가되었습니다.
	- 필수 필드가 `name`, `jobOccupation`, `locationIds`로 조정되었습니다.

- **문서화**
	- API 문서의 구조가 개선되어 각 매개변수 및 응답에 대한 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->