### PR TITLE
✨ 프로필 이미지 업로드, 삭제, 조회 API 추가

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1150,6 +1150,7 @@ components:
           $ref: '#/components/schemas/ProfileImageExtension'
       required:
           - imageId
+          - extension
 
     ProfileWidget:
       type: object

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -241,6 +241,32 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /users/my/profile-images/{imageId}:
+    delete:
+      summary: 프로필 이미지 삭제
+      description: 특정 프로필 이미지를 삭제합니다.
+      tags:
+        - users
+      operationId: deleteProfileImage
+      security:
+        - BearerAuth: [ ]
+      parameters:
+        - in: path
+          name: imageId
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: 삭제할 프로필 이미지 ID
+      responses:
+        '204':
+          description: 삭제 성공
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /users/my/desiredPartner:
     put:
@@ -751,6 +777,11 @@ components:
         name:
           type: string
           description: 사용자 이름
+        profileImages:
+          type: array
+          description: 프로필 이미지 목록
+          items:
+            $ref: '#/components/schemas/ProfileImage'
         phoneNumber:
           type: string
           description: 사용자의 전화번호 (한국 휴대폰 번호 형식)
@@ -1190,3 +1221,21 @@ components:
       type: string
       enum: [ PNG ]
       description: 프로필 이미지 확장자
+
+    ProfileImage:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: 이미지 식별자
+        url:
+          type: string
+          format: uri
+          description: 이미지 URL
+        extension:
+          $ref: '#/components/schemas/ProfileImageExtension'
+      required:
+        - id
+        - url
+        - extension


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- 사용자 프로필 이미지 삭제를 위한 새로운 API 엔드포인트 추가 (`/users/my/profile-images/{imageId}`).
	- 사용자 프로필 정보 응답에 `profileImages` 속성 추가, 프로필 이미지의 세부 정보 제공.
	- 프로필 이미지 업로드 요청 시 `extension` 속성 필수화.

- **개선 사항**
	- 프로필 이미지 관리 기능 향상 및 사용자 프로필 쿼리의 정보 개선.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->