### PR TITLE
유저 커넥션 조회 API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,8 +29,8 @@ paths:
           name: channelId
           required: true
           schema:
-              type: string
-              format: uuid
+            type: string
+            format: uuid
           description: 채널 ID
       requestBody:
         required: true
@@ -573,6 +573,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GetChannelMessagesResponse'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /connections/my/current:
+    get:
+      summary: 자신의 현재 커넥션을 조회합니다.
+      description: 자신의 현재 커넥션을 조회합니다.
+      tags:
+        - connections
+      security:
+        - BearerAuth: [ ]
+      responses:
+        '200':
+          description: 커넥션 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GetMyConnectionResponse'
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1458,3 +1480,112 @@ components:
       type: string
       enum: [ INFO, NEXT_CARD ]
       description: 시스템 메시지 타입
+
+    GetMyConnectionResponse:
+      type: object
+      properties:
+        connectionAttempt:
+          type: object
+          properties:
+            id:
+              type: string
+              format: uuid
+            userId:
+              type: string
+              format: uuid
+            connection:
+              $ref: '#/components/schemas/Connection'
+            status:
+              $ref: '#/components/schemas/ConnectionAttemptStatus'
+            attemptDate:
+              type: string
+            createdAt:
+              type: string
+          required:
+            - id
+            - userId
+            - status
+            - attemptDate
+            - createdAt
+
+    ConnectionAttemptStatus:
+      type: string
+      enum: [ CONNECTING, CONNECTED, FAILED, UNKNOWN ]
+      description: 커넥션 시도 상태
+
+    Connection:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        partner:
+          $ref: '#/components/schemas/Participant'
+        connectedAt:
+          type: string
+        cancellation:
+          $ref: '#/components/schemas/ConnectionCancellation'
+      required:
+        - id
+
+
+    Participant:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        name:
+          type: string
+          description: 사용자 이름
+        profileImages:
+          type: array
+          description: 프로필 이미지 목록
+          items:
+            $ref: '#/components/schemas/ProfileImage'
+        phoneNumber:
+          type: string
+          description: 사용자의 전화번호 (한국 휴대폰 번호 형식)
+          pattern: '^01[0-9]{8,9}$'
+        profile:
+          $ref: '#/components/schemas/UserProfileDisplayInfo'
+        profileWidgets:
+          type: array
+          items:
+            $ref: '#/components/schemas/ProfileWidget'
+      required:
+        - id
+        - userId
+        - name
+        - phoneNumber
+        - profile
+        - profileWidgets
+
+    ConnectionCancellation:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        userId:
+          type: string
+          format: uuid
+        reason:
+          $ref: '#/components/schemas/ConnectionCancellationReason'
+        detail:
+          type: string
+        createdAt:
+          type: string
+      required:
+        - id
+        - userId
+        - reason
+        - createdAt
+
+    ConnectionCancellationReason:
+      type: string
+      enum: [ NO_RESPONSE, FIRST_MESSAGE_TIMEOUT, DUPLICATED, REPORTED, ADMIN_CANCELLATION, ETC, UNKNOWN ]
+      description: 커넥션 취소 사유


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - 사용자가 현재 자신의 연결 정보를 조회할 수 있도록 하는 새로운 API 엔드포인트(`GET /connections/my/current`)가 추가되었습니다.
  - 이 엔드포인트는 인증된 사용자에게 제공되며, 성공 및 오류 응답이 체계적으로 구성되어 서비스 이용 경험을 향상시킵니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->