### PR TITLE
feat(chat): 채널 정보 조회 API

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -579,6 +579,38 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '404':
           $ref: '#/components/responses/NotFound'
+  /chat/channels/{channelId}:
+    get:
+      summary: 채널 정보 조회
+      description: 채널의 상세 정보를 조회합니다.
+      tags:
+        - chat
+      operationId: getChannel
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: channelId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+          description: 채널 ID
+      responses:
+        '200':
+          description: 채널 정보 조회 성공
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Channel'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '500':
+          $ref: '#/components/responses/InternalServerError'
 
   /connections/my/current:
     get:
@@ -1590,3 +1622,48 @@ components:
       type: string
       enum: [ NO_RESPONSE, FIRST_MESSAGE_TIMEOUT, DUPLICATED, REPORTED, ADMIN_CANCELLATION, ETC, UNKNOWN ]
       description: 커넥션 취소 사유
+
+    Channel:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: 채널 식별자
+        connectionId:
+          type: string
+          format: uuid
+          description: 커넥션 식별자
+        members:
+          type: array
+          items:
+            $ref: '#/components/schemas/ChannelMember'
+          description: 채널 멤버 목록
+        status:
+          type: string
+          enum: [ OPEN, PENDING, STRUCTURED_ONLY, CLOSED ]
+          description: 채널 상태
+        createdAt:
+          type: string
+          format: date-time
+          description: 채널 생성 시각
+      required:
+        - id
+        - connectionId
+        - members
+        - status
+        - createdAt
+
+    ChannelMember:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: 멤버(유저) 식별자
+        name:
+          type: string
+          description: 멤버 이름
+      required:
+        - id
+        - name


### PR DESCRIPTION
## 📅 일차별 채팅 흐름
### 🟡 1일차 채팅
- 시작 시 상태: STRUCTURED_ONLY
- 카드 메시지만 주고받기 가능
- 서버가 메시지 종류를 내려줌
- 카드 메시지 양쪽 모두 완료 → OPEN
- 종료 시 → PENDING

### 🟢 2일차 채팅
- 시작 시 → OPEN
- 종료 시 → PENDING

### 🟢 3일차 채팅
- 시작 시 → OPEN
- 종료 시 → PENDING

### 🔁 4일차 이후
- 계속해서 OPEN

### ❌ 예외 상황
- 참가자 중 한 명이라도 나가거나 거절한 경우 → CLOSED


```mermaid
stateDiagram-v2
    [*] --> OPEN : Channel.create()
    
    OPEN --> STRUCTURED_ONLY : 1일차 채팅 시작
    STRUCTURED_ONLY --> OPEN : 카드 메시지 양측 완료
    OPEN --> PENDING : 채팅 종료 (1~3일차)

    PENDING --> OPEN : 다음날 채팅 시작 (2~3일차)
    PENDING --> OPEN : 4일차 이후 채팅 시작

    OPEN --> CLOSED : 한 명이라도 나감 or 거절
    STRUCTURED_ONLY --> CLOSED : 한 명이라도 나감 or 거절
    PENDING --> CLOSED : 한 명이라도 나감 or 거절
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
    - 채널의 상세 정보를 조회할 수 있는 새로운 API 엔드포인트(`GET /chat/channels/{channelId}`)가 추가되었습니다.
    - 채널 및 채널 멤버 정보를 포함하는 새로운 데이터 구조가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->